### PR TITLE
Update Reader.tsx to Enable Internal Links in Epubs

### DIFF
--- a/src/Reader.tsx
+++ b/src/Reader.tsx
@@ -268,7 +268,7 @@ export function Reader({
             <TouchableWithoutFeedback onPress={handleDoublePress}>
               <WebView
                 ref={book}
-                source={{ html: template }}
+                source={{ html: template, baseUrl: 'app://local' }}
                 showsVerticalScrollIndicator={false}
                 javaScriptEnabled
                 injectedJavaScriptBeforeContentLoaded={injectedJS}


### PR DESCRIPTION
Simply adding an arbitrary "baseUrl" property to the WebView source in Reader will enable internal links to work! 