### PR TITLE
Update isURL.ts

### DIFF
--- a/src/utils/isURL.ts
+++ b/src/utils/isURL.ts
@@ -1,3 +1,3 @@
 export function isURL(value: string) {
-  return value.includes('http');
+  return value.slice(0,4) == 'http';
 }


### PR DESCRIPTION
Prior version of this file was returning false positives because some base64 encoded epubs include the base64 string 'http' somewhere in their body.