### PR TITLE
fix(template.ts): Make "onLocationsReady" great again

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -59,13 +59,21 @@ export default `
       book.ready
         .then(function () {
           if (initialLocations) {
-            book.locations.load(initialLocations);
-          } else book.locations.generate(1600);
+            return book.locations.load(initialLocations);
+          }
 
+          book.locations.generate(1600).then(function () {
+            window.ReactNativeWebView.postMessage(JSON.stringify({
+              type: "onLocationsReady",
+              epubKey: book.key(),
+              locations: book.locations.save(),
+            }));
+          });
+        })
+        .then(function () {
           var displayed = rendition.display();
 
           displayed.then(function () {
-            var viewer = document.getElementById("viewer");
             var currentLocation = rendition.currentLocation();
 
             window.ReactNativeWebView.postMessage(JSON.stringify({
@@ -114,12 +122,6 @@ export default `
               })
             );
           });
-          
-          window.ReactNativeWebView.postMessage(JSON.stringify({
-            type: "onLocationsReady",
-            epubKey: book.key(),
-            locations: book.locations.save(),
-          }));
 
           book.loaded.navigation.then(function (toc) {
             window.ReactNativeWebView.postMessage(JSON.stringify({

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,7 +136,7 @@ export interface ReaderProps {
    */
   onLocationChange?: (
     totalLocations: number,
-    currentLocation: number,
+    currentLocation: Location,
     progress: number
   ) => void;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,7 +150,7 @@ export interface ReaderProps {
    * @param {string} locations
    * @returns {void} void
    */
-  onLocationsReady?: (epubKey: string, locations: Location[]) => void;
+  onLocationsReady?: (epubKey: string, locations: ePubCfi[]) => void;
   /**
    * Called once a text selection has occurred
    * @param {SelectedText} selectedText


### PR DESCRIPTION
This one fix the issue #68 with awaiting for locations ready event.
I'm using this thing to enable progress instantly for second book opening. At first run we are still awaiting for `generate` to do all the job, so that we can `load` it lately.

Also, accounted case for non-blocking book render while generating.