### PR TITLE
remove expo-file-system as a dependency

### DIFF
--- a/example-bare/package.json
+++ b/example-bare/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@epubjs-react-native/core": "^1.3.0",
-    "@epubjs-react-native/file-system": "^1.1.1",
+    "@epubjs-react-native/file-system": "^1.1.2-beta.1",
     "@react-navigation/native": "^6.1.15",
     "@react-navigation/native-stack": "^6.9.24",
     "expo": "~50.0.11",

--- a/example-bare/yarn.lock
+++ b/example-bare/yarn.lock
@@ -1211,10 +1211,10 @@
   resolved "https://registry.yarnpkg.com/@epubjs-react-native/core/-/core-1.3.0.tgz#dd6410265098f5680cb7ac5396860b443358786f"
   integrity sha512-wyjifLuRxyDX0msm4G85RQ0OTe+ATYvLgkFxoR1kzznUgPOuoU3s4vBZMD1KwpcwlomxJoJXBOFS7nzuW7nhRw==
 
-"@epubjs-react-native/file-system@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@epubjs-react-native/file-system/-/file-system-1.1.1.tgz#a2e9954ac332cbbacc8c334ebd0ce528880e054d"
-  integrity sha512-4aL7jEFzA1NxY7i/uo8rkdTD/IrEOFadQQenaXLsfCg+Iu0J8AWyoBS2hrWmWfb5bomDk5PREbsfOPhEvIYMRw==
+"@epubjs-react-native/file-system@^1.1.2-beta.1":
+  version "1.1.2-beta.1"
+  resolved "https://registry.yarnpkg.com/@epubjs-react-native/file-system/-/file-system-1.1.2-beta.1.tgz#571bfcb882db9798f2c6cb5d39a2a04687b6d958"
+  integrity sha512-AaFkk8IhIaEbr+FMbMDmfaz3TAt5r33TSKe84DAHDXMfLQ6nLYyX1wFdkr65k4KdkfquIagesaO0AiokyeE3HA==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"

--- a/example-expo/package.json
+++ b/example-expo/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@epubjs-react-native/core": "^1.3.0",
-    "@epubjs-react-native/expo-file-system": "^1.1.1",
+    "@epubjs-react-native/expo-file-system": "^1.1.2-beta.1",
     "@react-navigation/native": "^6.1.15",
     "@react-navigation/native-stack": "^6.9.24",
     "expo": "^50.0.1",

--- a/example-expo/yarn.lock
+++ b/example-expo/yarn.lock
@@ -1211,10 +1211,10 @@
   resolved "https://registry.yarnpkg.com/@epubjs-react-native/core/-/core-1.3.0.tgz#dd6410265098f5680cb7ac5396860b443358786f"
   integrity sha512-wyjifLuRxyDX0msm4G85RQ0OTe+ATYvLgkFxoR1kzznUgPOuoU3s4vBZMD1KwpcwlomxJoJXBOFS7nzuW7nhRw==
 
-"@epubjs-react-native/expo-file-system@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@epubjs-react-native/expo-file-system/-/expo-file-system-1.1.1.tgz#72bb6f4b2f90a2196968073d62465032dc50eb34"
-  integrity sha512-5iS7oj5UXXRoyNTdwDCacNXeYPl7jueGMXl5Tcdzya0aYOMHKK3gzxk07s4vsapiTnRJval1Q5PqXdSomfFt9w==
+"@epubjs-react-native/expo-file-system@^1.1.2-beta.1":
+  version "1.1.2-beta.1"
+  resolved "https://registry.yarnpkg.com/@epubjs-react-native/expo-file-system/-/expo-file-system-1.1.2-beta.1.tgz#89f89168dc3cc98f5a28c338f2853169846678fa"
+  integrity sha512-v+3fxk3sqRKkcxiBeTS38EnuBzQa0SGmJUfw5fSPCnJ0VrhTXtlOrsQeXpfdnaOJ698p3mGwunT2pgMh+zBvYg==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "eslint-plugin-react": "7.34.0",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-testing-library": "6.2.0",
-    "expo-file-system": "~16.0.0",
     "husky": "9.0.11",
     "jest": "29.7.0",
     "lint-staged": "15.2.2",
@@ -97,11 +96,9 @@
     "typescript": "^5.1.3"
   },
   "resolutions": {
-    "@types/react": "~18.2.0",
-    "expo-file-system": "~16.0.0"
+    "@types/react": "~18.2.0"
   },
   "peerDependencies": {
-    "expo-file-system": "16.0.8",
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": "^2.12.0",

--- a/src/Reader.tsx
+++ b/src/Reader.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useState } from 'react';
-import * as FileSystem from 'expo-file-system';
 import { LoadingFile } from './utils/LoadingFile';
 import type { ReaderProps } from './types';
 import { View } from './View';
@@ -13,7 +12,6 @@ import { isFsUri } from './utils/isFsUri';
 import jszip from './jszip';
 import epubjs from './epubjs';
 
-// ...
 export function Reader({
   src,
   width,
@@ -32,6 +30,8 @@ export function Reader({
     progress: downloadProgress,
     success: downloadSuccess,
     error: downloadError,
+    documentDirectory,
+    writeAsStringAsync,
   } = useFileSystem();
 
   const { setIsLoading, isLoading } = useContext(ReaderContext);
@@ -44,17 +44,17 @@ export function Reader({
     (async () => {
       setIsLoading(true);
 
-      const jszipFileUri = `${FileSystem.documentDirectory}jszip.min.js`;
-      const epubjsFileUri = `${FileSystem.documentDirectory}epub.min.js`;
+      const jszipFileUri = `${documentDirectory}jszip.min.js`;
+      const epubjsFileUri = `${documentDirectory}epub.min.js`;
 
       try {
-        await FileSystem.writeAsStringAsync(jszipFileUri, jszip);
+        await writeAsStringAsync(jszipFileUri, jszip);
       } catch (e) {
         throw new Error('failed to write jszip js file');
       }
 
       try {
-        await FileSystem.writeAsStringAsync(epubjsFileUri, epubjs);
+        await writeAsStringAsync(epubjsFileUri, epubjs);
       } catch (e) {
         throw new Error('failed to write epubjs js file');
       }
@@ -152,11 +152,13 @@ export function Reader({
     })();
   }, [
     defaultTheme,
+    documentDirectory,
     downloadFile,
     initialLocations,
     injectWebVieWVariables,
     setIsLoading,
     src,
+    writeAsStringAsync,
   ]);
 
   useEffect(() => {
@@ -165,8 +167,8 @@ export function Reader({
         if (template) {
           const content = template;
 
-          const fileUri = `${FileSystem.documentDirectory}index.html`;
-          await FileSystem.writeAsStringAsync(fileUri, content);
+          const fileUri = `${documentDirectory}index.html`;
+          await writeAsStringAsync(fileUri, content);
           setTemplateUrl(fileUri);
         }
       } catch (error) {
@@ -176,7 +178,7 @@ export function Reader({
     if (template) {
       saveTemplateFileToDoc();
     }
-  }, [template]);
+  }, [documentDirectory, template, writeAsStringAsync]);
 
   if (isLoading) {
     return renderLoadingFileComponent({

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,23 @@ type FileSystem = {
   size: number;
   error: string | null;
   success: boolean;
+  documentDirectory: string | null;
+  cacheDirectory: string | null;
+  bundleDirectory: string | null;
+  readAsStringAsync: (
+    fileUri: string,
+    options?: {
+      encoding?: 'utf8' | 'base64';
+    }
+  ) => Promise<string>;
+  writeAsStringAsync: (
+    fileUri: string,
+    contents: string,
+    options?: {
+      encoding?: 'utf8' | 'base64';
+    }
+  ) => Promise<void>;
+  deleteAsync: (fileUri: string) => Promise<void>;
   downloadFile: (
     fromUrl: string,
     toFile: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -4143,11 +4143,6 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-expo-file-system@~16.0.0:
-  version "16.0.8"
-  resolved "https://registry.npmjs.org/expo-file-system/-/expo-file-system-16.0.8.tgz"
-  integrity sha512-yDbVT0TUKd7ewQjaY5THum2VRFx2n/biskGhkUmLh3ai21xjIVtaeIzHXyv9ir537eVgt4ReqDNWi7jcXjdUcA==
-
 external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz"


### PR DESCRIPTION
This pull request resolves issue #116 which occurs because the library depends directly on expo-file-system, the library was removed from the source code, it should only be added as explained in readme.md