### PR TITLE
Fix Expo Formats example not switching books

### DIFF
--- a/example-expo/examples/Formats/index.tsx
+++ b/example-expo/examples/Formats/index.tsx
@@ -75,6 +75,7 @@ export function Formats() {
 
       <ReaderProvider>
         <Reader
+          key={src}
           src={src}
           width={width}
           height={height * 0.7}


### PR DESCRIPTION
## Summary
- Remount `Reader` with `key={src}` in the Expo Formats example so changing OPF / EPUB / base64 / local actually reloads the book.
- Expo Go's WebView does not reload when the core rewrites the same `index.html` URI; the bare example already worked. No core change.

## Test plan
- [ ] Open `example-expo` Formats on Android (Expo Go).
- [ ] Switch Book (.opf) → Book (.epub) → Book (base64); the footer and the book both change.
- [ ] Confirm `example-bare` Formats still works.

Made with [Cursor](https://cursor.com)