### PR TITLE
Release 1.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epubjs-react-native/core",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "A digital book reader in .opf .epub format for react native using epub.js library inside a webview.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary
- Bump `@epubjs-react-native/core` to **1.4.8** so the GitHub tag and npm version match.

## Test plan
- [ ] `package.json` version is 1.4.8.
- [ ] Tag `v1.4.8` after merge.

Made with [Cursor](https://cursor.com)