### PR TITLE
fix: keep displayed spine sections loaded after search

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -869,35 +869,54 @@ function ReaderProvider({ children }: { children: React.ReactNode }) {
           JSON.stringify({ type: 'onSearch', results: [] })
         );
       } else {
-         Promise.all(
+        Promise.all(
           book.spine.spineItems.map(async (item) => {
-            const wasLoaded = !!item.document;
+            const views = rendition.views();
+            let isDisplayed = false;
+            if (views && views.forEach) {
+              views.forEach(function (view) {
+                if (
+                  view &&
+                  view.displayed &&
+                  view.section &&
+                  view.section.index === item.index
+                ) {
+                  isDisplayed = true;
+                }
+              });
+            }
 
-            if(!wasLoaded) {
+            if (!isDisplayed) {
               await item.load(book.load.bind(book));
             }
-              
-            let results = item.find(term.trim());
-            const locationHref = item.href;
 
-            let [match] = flatten(book.navigation.toc)
-            .filter((chapter, index) => {
-                return book.canonical(chapter.href).includes(locationHref)
-            }, null);
+            try {
+              if (!item.document) {
+                return [];
+              }
 
-            if (results.length > 0) {
-              results = results.map(result => ({ ...result, section: { ...match, index: book.navigation.toc.findIndex(elem => elem.id === match?.id) } }));
+              let results = item.find(term.trim());
+              const locationHref = item.href;
 
-              if (chapterId) {
-                results = results.filter(result => result.section.id === chapterId);
+              let [match] = flatten(book.navigation.toc)
+              .filter((chapter, index) => {
+                  return book.canonical(chapter.href).includes(locationHref)
+              }, null);
+
+              if (results.length > 0) {
+                results = results.map(result => ({ ...result, section: { ...match, index: book.navigation.toc.findIndex(elem => elem.id === match?.id) } }));
+
+                if (chapterId) {
+                  results = results.filter(result => result.section.id === chapterId);
+                }
+              }
+
+              return results;
+            } finally {
+              if (!isDisplayed) {
+                item.unload();
               }
             }
-
-            if(!wasLoaded){
-              item.unload();
-            }
-
-            return results;
           })
         ).then((results) => {
           const items = [].concat.apply([], results);


### PR DESCRIPTION
## Summary
- Follow-up to #399: skip `unload()` only when the spine item is currently in a displayed rendition view, not based on a `document` snapshot.
- Load/find run inside `try/finally` so overlapping searches cannot `find()` a document another search already cleared, and newly loaded sections are always unloaded if they are not on screen.
- `find()` is skipped when `item.document` is missing.

## Test plan
- [ ] Type quickly in example-expo Search (keystroke `search()`)
- [ ] Results still appear
- [ ] After search, turn pages and confirm `onLocationChange` still updates progress/chapter

EOF