### PR TITLE
fix: stabilize iOS text selection after page turns

### DIFF
--- a/src/View.tsx
+++ b/src/View.tsx
@@ -42,6 +42,7 @@ export function View({
   width,
   height,
   initialLocation,
+  enableSelection = false,
   enableSwipe = true,
   onSwipeLeft = () => {},
   onSwipeRight = () => {},
@@ -469,6 +470,10 @@ export function View({
         ref={book}
         source={{ uri: templateUri }}
         showsVerticalScrollIndicator={false}
+        showsHorizontalScrollIndicator={false}
+        textInteractionEnabled={!!enableSelection}
+        allowsLinkPreview={false}
+        dataDetectorTypes="none"
         javaScriptEnabled
         originWhitelist={['*']}
         scrollEnabled={false}


### PR DESCRIPTION
## Summary
- Sets iOS `WebView` props that compete with word selection after a page turn: `textInteractionEnabled` follows `enableSelection`, plus `allowsLinkPreview={false}`, `dataDetectorTypes="none"`, and `showsHorizontalScrollIndicator={false}`.
- Does **not** take the rest of the community patch on #409 (shell `injectedJavaScript` on `document.body`, `scalesPageToFit`, media/keyboard flags). EPUB text lives in epub.js iframes, not the WebView shell.
- GestureHandler long-press/fling on iOS is left as a follow-up if selection still fails on device.

Fixes https://github.com/victorsoares96/epubjs-react-native/issues/409

## Test plan
- [ ] iOS simulator or device (the actual bug): open a book with `menuItems` (e.g. FullExample), swipe several pages, then long-press a word. Selection handles and the custom menu should still appear.
- [ ] Same flow with `enableSelection` unset and no `menuItems`: native text interaction should stay off.
- [ ] Android smoke: book still opens, swipe still works (these props are iOS-oriented).
- [ ] Links in the book still open via `onPressExternalLink` (link preview is disabled on iOS).

Made with [Cursor](https://cursor.com)