### PR TITLE
fix: re-show iOS custom selection menus after selection changes

### DIFF
--- a/src/View.tsx
+++ b/src/View.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { Dimensions, View as RNView } from 'react-native';
+import { Dimensions, Platform, View as RNView } from 'react-native';
 import { WebView } from 'react-native-webview';
 import type {
   ShouldStartLoadRequest,
@@ -10,6 +10,10 @@ import type { Bookmark, ReaderProps } from './types';
 import { OpeningBook } from './utils/OpeningBook';
 import INTERNAL_EVENTS from './utils/internalEvents.util';
 import { GestureHandler } from './utils/GestureHandler';
+import { SelectionMenu } from './utils/SelectionMenu';
+import { SELECTION_MENU_BRIDGE_SCRIPT } from './utils/selectionMenuBridge';
+import type { SelectionRect } from './utils/getSelectionMenuPosition';
+import { shouldUseIosSelectionOverlay } from './utils/shouldUseIosSelectionOverlay';
 
 export type ViewProps = Omit<ReaderProps, 'src' | 'fileSystem'> & {
   templateUri: string;
@@ -116,6 +120,25 @@ export function View({
     cfiRange: string;
     cfiRangeText: string;
   }>({ cfiRange: '', cfiRangeText: '' });
+  const selectedTextRef = useRef(selectedText);
+  selectedTextRef.current = selectedText;
+  const useIosSelectionMenu = shouldUseIosSelectionOverlay(
+    Platform.OS,
+    menuItems
+  );
+  const [selectionRect, setSelectionRect] = useState<SelectionRect | null>(
+    null
+  );
+  const [isSelectionMenuVisible, setIsSelectionMenuVisible] = useState(false);
+  const [viewport, setViewport] = useState({
+    width: typeof width === 'number' ? width : 0,
+    height: typeof height === 'number' ? height : 0,
+  });
+
+  const injectSelectionMenuBridge = () => {
+    if (!useIosSelectionMenu) return;
+    book.current?.injectJavaScript(SELECTION_MENU_BRIDGE_SCRIPT);
+  };
 
   useEffect(() => {
     setFlow(flow || 'auto');
@@ -183,6 +206,8 @@ export function View({
         book.current?.injectJavaScript(injectedJavascript);
       }
 
+      injectSelectionMenuBridge();
+
       return onReady(totalLocations, currentLocation, progress);
     }
 
@@ -212,6 +237,7 @@ export function View({
       }
 
       handleChangeIsBookmarked(bookmarks, currentLocation);
+      setIsSelectionMenuVisible(false);
 
       if (currentLocation.atStart) setAtStart(true);
       else if (currentLocation.atEnd) setAtEnd(true);
@@ -252,10 +278,19 @@ export function View({
     }
 
     if (type === 'onSelected') {
-      const { cfiRange, text } = parsedEvent;
+      const { cfiRange, text, rect } = parsedEvent;
 
       setSelectedText({ cfiRange, cfiRangeText: text });
+      if (useIosSelectionMenu && text) {
+        setSelectionRect(rect ?? null);
+        setIsSelectionMenuVisible(true);
+      }
       return onSelected(text, cfiRange);
+    }
+
+    if (type === 'onSelectionCleared') {
+      setIsSelectionMenuVisible(false);
+      return () => {};
     }
 
     if (type === 'onOrientationChange') {
@@ -278,6 +313,7 @@ export function View({
 
     if (type === 'onRendered') {
       const { currentSection } = parsedEvent;
+      injectSelectionMenuBridge();
 
       return onRendered(parsedEvent.section, currentSection);
     }
@@ -362,6 +398,23 @@ export function View({
     return () => {};
   };
 
+  const runMenuItemAction = (label: string) => {
+    menuItems?.forEach((item) => {
+      if (label === item.label) {
+        const removeSelectionMenu = item.action(
+          selectedTextRef.current.cfiRange,
+          selectedTextRef.current.cfiRangeText
+        );
+
+        setIsSelectionMenuVisible(false);
+
+        if (removeSelectionMenu) {
+          removeSelection();
+        }
+      }
+    });
+  };
+
   const handleOnCustomMenuSelection = (event: {
     nativeEvent: {
       label: string;
@@ -369,18 +422,7 @@ export function View({
       selectedText: string;
     };
   }) => {
-    menuItems?.forEach((item) => {
-      if (event.nativeEvent.label === item.label) {
-        const removeSelectionMenu = item.action(
-          selectedText.cfiRange,
-          selectedText.cfiRangeText
-        );
-
-        if (removeSelectionMenu) {
-          removeSelection();
-        }
-      }
-    });
+    runMenuItemAction(event.nativeEvent.label);
   };
 
   const handleOnShouldStartLoadWithRequest = (
@@ -415,94 +457,121 @@ export function View({
   }, [registerBook]);
 
   return (
-    <GestureHandler
-      width={width}
-      height={height}
-      onSingleTap={() => {
-        onPress();
-        onSingleTap();
-      }}
-      onDoubleTap={() => {
-        onDoublePress();
-        onDoubleTap();
-      }}
-      onLongPress={onLongPress}
-      onSwipeLeft={() => {
-        if (enableSwipe) {
-          goNext({
-            keepScrollOffset: keepScrollOffsetOnLocationChange,
-          });
-          onSwipeLeft();
-        }
-      }}
-      onSwipeRight={() => {
-        if (enableSwipe) {
-          goPrevious({
-            keepScrollOffset: keepScrollOffsetOnLocationChange,
-          });
-          onSwipeRight();
-        }
-      }}
-      onSwipeUp={() => {
-        if (enableSwipe) {
-          onSwipeUp();
-        }
-      }}
-      onSwipeDown={() => {
-        if (enableSwipe) {
-          onSwipeDown();
-        }
+    <RNView
+      style={{ width, height }}
+      onLayout={(event) => {
+        const { width: nextWidth, height: nextHeight } =
+          event.nativeEvent.layout;
+        setViewport((current) =>
+          current.width === nextWidth && current.height === nextHeight
+            ? current
+            : { width: nextWidth, height: nextHeight }
+        );
       }}
     >
-      {isRendering && (
-        <RNView
-          style={{
-            ...openingBookComponentContainerStyle,
-            position: 'absolute',
-            zIndex: 2,
-          }}
-        >
-          {renderOpeningBookComponent()}
-        </RNView>
-      )}
-
-      <WebView
-        ref={book}
-        source={{ uri: templateUri }}
-        showsVerticalScrollIndicator={false}
-        showsHorizontalScrollIndicator={false}
-        textInteractionEnabled={!!enableSelection}
-        allowsLinkPreview={false}
-        dataDetectorTypes="none"
-        javaScriptEnabled
-        originWhitelist={['*']}
-        scrollEnabled={false}
-        mixedContentMode="compatibility"
-        onMessage={onMessage}
-        menuItems={menuItems?.map((item, key) => ({
-          label: item.label,
-          key: key.toString(),
-        }))}
-        onCustomMenuSelection={handleOnCustomMenuSelection}
-        allowingReadAccessToURL={allowedUris}
-        allowUniversalAccessFromFileURLs
-        allowFileAccessFromFileURLs
-        allowFileAccess
-        javaScriptCanOpenWindowsAutomatically
-        onOpenWindow={(event) => {
-          event.preventDefault();
-
-          if (onPressExternalLink) {
-            onPressExternalLink(event.nativeEvent.targetUrl);
+      <GestureHandler
+        width={width}
+        height={height}
+        onSingleTap={() => {
+          onPress();
+          onSingleTap();
+        }}
+        onDoubleTap={() => {
+          onDoublePress();
+          onDoubleTap();
+        }}
+        onLongPress={onLongPress}
+        onSwipeLeft={() => {
+          if (enableSwipe) {
+            goNext({
+              keepScrollOffset: keepScrollOffsetOnLocationChange,
+            });
+            onSwipeLeft();
           }
         }}
-        onShouldStartLoadWithRequest={handleOnShouldStartLoadWithRequest}
-        style={{
-          width,
-          backgroundColor: theme.body.background,
-          height,
+        onSwipeRight={() => {
+          if (enableSwipe) {
+            goPrevious({
+              keepScrollOffset: keepScrollOffsetOnLocationChange,
+            });
+            onSwipeRight();
+          }
         }}
-      />
-    </GestureHandler>
+        onSwipeUp={() => {
+          if (enableSwipe) {
+            onSwipeUp();
+          }
+        }}
+        onSwipeDown={() => {
+          if (enableSwipe) {
+            onSwipeDown();
+          }
+        }}
+      >
+        {isRendering && (
+          <RNView
+            style={{
+              ...openingBookComponentContainerStyle,
+              position: 'absolute',
+              zIndex: 2,
+            }}
+          >
+            {renderOpeningBookComponent()}
+          </RNView>
+        )}
+
+        <WebView
+          ref={book}
+          source={{ uri: templateUri }}
+          showsVerticalScrollIndicator={false}
+          showsHorizontalScrollIndicator={false}
+          textInteractionEnabled={!!enableSelection}
+          allowsLinkPreview={false}
+          dataDetectorTypes="none"
+          javaScriptEnabled
+          originWhitelist={['*']}
+          scrollEnabled={false}
+          mixedContentMode="compatibility"
+          onMessage={onMessage}
+          menuItems={
+            useIosSelectionMenu
+              ? []
+              : menuItems?.map((item, key) => ({
+                  label: item.label,
+                  key: key.toString(),
+                }))
+          }
+          onCustomMenuSelection={
+            useIosSelectionMenu ? undefined : handleOnCustomMenuSelection
+          }
+          allowingReadAccessToURL={allowedUris}
+          allowUniversalAccessFromFileURLs
+          allowFileAccessFromFileURLs
+          allowFileAccess
+          javaScriptCanOpenWindowsAutomatically
+          onOpenWindow={(event) => {
+            event.preventDefault();
+
+            if (onPressExternalLink) {
+              onPressExternalLink(event.nativeEvent.targetUrl);
+            }
+          }}
+          onShouldStartLoadWithRequest={handleOnShouldStartLoadWithRequest}
+          style={{
+            width,
+            backgroundColor: theme.body.background,
+            height,
+          }}
+        />
+      </GestureHandler>
+      {useIosSelectionMenu && isSelectionMenuVisible && menuItems && (
+        <SelectionMenu
+          items={menuItems}
+          selection={selectionRect}
+          viewport={viewport}
+          onPressItem={runMenuItemAction}
+        />
+      )}
+    </RNView>
   );
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -326,13 +326,70 @@ export default `
         }));
       });
 
+      function getSelectionRectInWebView(contents, range) {
+        if (!range) return null;
+
+        var rects = range.getClientRects();
+        var top = Infinity;
+        var left = Infinity;
+        var right = -Infinity;
+        var bottom = -Infinity;
+        var i;
+        var rect;
+
+        if (rects && rects.length) {
+          for (i = 0; i < rects.length; i++) {
+            rect = rects[i];
+            if (!rect.width && !rect.height) continue;
+            top = Math.min(top, rect.top);
+            left = Math.min(left, rect.left);
+            right = Math.max(right, rect.right);
+            bottom = Math.max(bottom, rect.bottom);
+          }
+        }
+
+        if (!isFinite(top)) {
+          rect = range.getBoundingClientRect();
+          if (!rect || (!rect.width && !rect.height)) return null;
+          top = rect.top;
+          left = rect.left;
+          right = rect.right;
+          bottom = rect.bottom;
+        }
+
+        var offsetX = 0;
+        var offsetY = 0;
+        try {
+          var win = contents && contents.window;
+          while (win && win !== window) {
+            var frame = win.frameElement;
+            if (!frame) break;
+            var frameRect = frame.getBoundingClientRect();
+            offsetX += frameRect.left;
+            offsetY += frameRect.top;
+            win = win.parent;
+          }
+        } catch (error) {}
+
+        return {
+          x: left + offsetX,
+          y: top + offsetY,
+          width: right - left,
+          height: bottom - top
+        };
+      }
+      window.getSelectionRectInWebView = getSelectionRectInWebView;
+
       rendition.on("selected", function (cfiRange, contents) {
         book.getRange(cfiRange).then(function (range) {
           if (range) {
+            var sel = contents && contents.window && contents.window.getSelection();
+            var liveRange = sel && sel.rangeCount > 0 ? sel.getRangeAt(0) : range;
             reactNativeWebview.postMessage(JSON.stringify({
               type: 'onSelected',
               cfiRange: cfiRange,
               text: range.toString(),
+              rect: getSelectionRectInWebView(contents, liveRange)
             }));
           }
         });

--- a/src/types.ts
+++ b/src/types.ts
@@ -426,6 +426,9 @@ export interface ReaderProps {
   /**
    * An array of objects which will be shown when selecting text. An empty array will suppress the menu.
    * These will appear after a long press to select text.
+   *
+   * On iOS, items are rendered in a React Native overlay so the menu can reappear
+   * when the selection changes. Android keeps the native WebView menu.
    * @platform ios, android
    */
   menuItems?: Array<{

--- a/src/utils/SelectionMenu.tsx
+++ b/src/utils/SelectionMenu.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type LayoutChangeEvent,
+} from 'react-native';
+import {
+  getSelectionMenuPosition,
+  type SelectionRect,
+} from './getSelectionMenuPosition';
+
+type MenuItem = {
+  key?: string;
+  label: string;
+};
+
+type Props = {
+  items: MenuItem[];
+  selection: SelectionRect | null;
+  viewport: { width: number; height: number };
+  onLayoutMenu?: (size: { width: number; height: number }) => void;
+  onPressItem: (label: string) => void;
+};
+
+const styles = StyleSheet.create({
+  menu: {
+    position: 'absolute',
+    maxWidth: '92%',
+    borderRadius: 10,
+    backgroundColor: '#2c2c2e',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 6,
+    elevation: 6,
+  },
+  items: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    paddingHorizontal: 4,
+  },
+  item: {
+    minHeight: 44,
+    minWidth: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+  },
+  itemPressed: {
+    opacity: 0.7,
+  },
+  label: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  separator: {
+    alignSelf: 'stretch',
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    marginVertical: 8,
+    width: StyleSheet.hairlineWidth,
+  },
+});
+
+export function SelectionMenu({
+  items,
+  selection,
+  viewport,
+  onLayoutMenu,
+  onPressItem,
+}: Props) {
+  const [menuSize, setMenuSize] = React.useState({ width: 0, height: 44 });
+  const position = getSelectionMenuPosition(selection, menuSize, viewport);
+
+  const handleLayout = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    if (width === menuSize.width && height === menuSize.height) {
+      return;
+    }
+    setMenuSize({ width, height });
+    onLayoutMenu?.({ width, height });
+  };
+
+  return (
+    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+      <View
+        onLayout={handleLayout}
+        pointerEvents="auto"
+        style={[styles.menu, { top: position.top, left: position.left }]}
+      >
+        <ScrollView
+          horizontal
+          bounces={false}
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.items}
+        >
+          {items.map((item, index) => (
+            <React.Fragment key={item.key ?? `${item.label}-${index}`}>
+              {index > 0 && <View style={styles.separator} />}
+              <Pressable
+                accessibilityRole="button"
+                onPress={() => onPressItem(item.label)}
+                style={({ pressed }) => [
+                  styles.item,
+                  pressed && styles.itemPressed,
+                ]}
+              >
+                <Text style={styles.label}>{item.label}</Text>
+              </Pressable>
+            </React.Fragment>
+          ))}
+        </ScrollView>
+      </View>
+    </View>
+  );
+}

--- a/src/utils/getSelectionMenuPosition.test.ts
+++ b/src/utils/getSelectionMenuPosition.test.ts
@@ -1,0 +1,65 @@
+import { getSelectionMenuPosition } from './getSelectionMenuPosition';
+
+const menuSize = { width: 180, height: 44 };
+const viewport = { width: 390, height: 700 };
+
+describe('getSelectionMenuPosition', () => {
+  it('places the menu above the selection when there is room', () => {
+    const position = getSelectionMenuPosition(
+      { x: 100, y: 200, width: 80, height: 20 },
+      menuSize,
+      viewport
+    );
+
+    expect(position.placement).toBe('above');
+    expect(position.top).toBe(200 - 44 - 8);
+    expect(position.left).toBe(100 + 40 - 90);
+  });
+
+  it('places the menu below the selection when it would overflow the top', () => {
+    const position = getSelectionMenuPosition(
+      { x: 40, y: 10, width: 60, height: 18 },
+      menuSize,
+      viewport
+    );
+
+    expect(position.placement).toBe('below');
+    expect(position.top).toBe(10 + 18 + 8);
+  });
+
+  it('clamps the menu inside the viewport horizontally', () => {
+    const nearRightEdge = getSelectionMenuPosition(
+      { x: 360, y: 200, width: 20, height: 20 },
+      menuSize,
+      viewport
+    );
+    const nearLeftEdge = getSelectionMenuPosition(
+      { x: 4, y: 200, width: 10, height: 20 },
+      menuSize,
+      viewport
+    );
+
+    expect(nearRightEdge.left).toBe(viewport.width - menuSize.width - 8);
+    expect(nearLeftEdge.left).toBe(8);
+  });
+
+  it('falls back to the top of the viewport without a selection rect', () => {
+    const position = getSelectionMenuPosition(null, menuSize, viewport);
+
+    expect(position.placement).toBe('below');
+    expect(position.top).toBe(8);
+    expect(position.left).toBe((viewport.width - menuSize.width) / 2);
+  });
+
+  it('keeps the menu inside a viewport smaller than the menu', () => {
+    const position = getSelectionMenuPosition(
+      { x: 10, y: 20, width: 30, height: 16 },
+      { width: 200, height: 44 },
+      { width: 80, height: 90 }
+    );
+
+    expect(position.left).toBe(8);
+    expect(position.top).toBeGreaterThanOrEqual(8);
+    expect(position.top + 44).toBeLessThanOrEqual(90);
+  });
+});

--- a/src/utils/getSelectionMenuPosition.ts
+++ b/src/utils/getSelectionMenuPosition.ts
@@ -1,0 +1,47 @@
+export type SelectionRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type SelectionMenuPlacement = 'above' | 'below';
+
+export function getSelectionMenuPosition(
+  selection: SelectionRect | null,
+  menuSize: { width: number; height: number },
+  viewport: { width: number; height: number },
+  gap = 8
+): { top: number; left: number; placement: SelectionMenuPlacement } {
+  const menuWidth = Math.min(
+    menuSize.width,
+    Math.max(0, viewport.width - gap * 2)
+  );
+  const menuHeight = menuSize.height;
+
+  if (!selection) {
+    return {
+      top: gap,
+      left: Math.max(gap, (viewport.width - menuWidth) / 2),
+      placement: 'below',
+    };
+  }
+
+  const centeredLeft = selection.x + selection.width / 2 - menuWidth / 2;
+  const maxLeft = Math.max(gap, viewport.width - menuWidth - gap);
+  const left = Math.min(Math.max(gap, centeredLeft), maxLeft);
+
+  const aboveTop = selection.y - menuHeight - gap;
+  if (aboveTop >= gap) {
+    return { top: aboveTop, left, placement: 'above' };
+  }
+
+  const belowTop = selection.y + selection.height + gap;
+  const maxTop = Math.max(gap, viewport.height - menuHeight - gap);
+
+  return {
+    top: Math.min(belowTop, maxTop),
+    left,
+    placement: 'below',
+  };
+}

--- a/src/utils/internalEvents.util.ts
+++ b/src/utils/internalEvents.util.ts
@@ -8,6 +8,7 @@ const INTERNAL_EVENTS = [
   'onSearch',
   'onLocationsReady',
   'onSelected',
+  'onSelectionCleared',
   'onOrientationChange',
   'onBeginning',
   'onFinish',

--- a/src/utils/selectionMenuBridge.ts
+++ b/src/utils/selectionMenuBridge.ts
@@ -1,0 +1,81 @@
+/**
+ * Injected into the book WebView on iOS when custom menuItems are present.
+ * Suppresses the native callout and re-emits selection so the RN overlay can
+ * reappear after handle drags and taps on an existing selection.
+ */
+export const SELECTION_MENU_BRIDGE_SCRIPT = `
+(function () {
+  try {
+    if (typeof rendition === 'undefined' || !rendition) {
+      true;
+      return;
+    }
+
+    rendition.themes.default({
+      'body': {
+        '-webkit-touch-callout': 'none'
+      }
+    });
+
+    function postSelection(contents) {
+      var sel = contents.window.getSelection();
+      if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
+        reactNativeWebview.postMessage(JSON.stringify({ type: 'onSelectionCleared' }));
+        return;
+      }
+
+      var range = sel.getRangeAt(0);
+      var cfiRange = contents.cfiFromRange
+        ? contents.cfiFromRange(range)
+        : new ePub.CFI(range, contents.cfiBase).toString();
+      var rect = null;
+      if (typeof window.getSelectionRectInWebView === 'function') {
+        rect = window.getSelectionRectInWebView(contents, range);
+      }
+
+      reactNativeWebview.postMessage(JSON.stringify({
+        type: 'onSelected',
+        cfiRange: cfiRange,
+        text: range.toString(),
+        rect: rect
+      }));
+    }
+
+    function bindSelectionMenuBridge(contents) {
+      if (!contents || !contents.document || contents.document.__rnSelectionMenuBound) {
+        return;
+      }
+
+      contents.document.__rnSelectionMenuBound = true;
+
+      if (contents.document.documentElement && contents.document.documentElement.style) {
+        contents.document.documentElement.style.webkitTouchCallout = 'none';
+      }
+
+      contents.document.addEventListener('contextmenu', function (event) {
+        event.preventDefault();
+      });
+
+      contents.document.addEventListener('touchend', function () {
+        setTimeout(function () {
+          postSelection(contents);
+        }, 0);
+      }, { passive: true });
+    }
+
+    if (rendition.getContents) {
+      rendition.getContents().forEach(bindSelectionMenuBridge);
+    }
+
+    if (
+      !window.__rnSelectionMenuHookRegistered &&
+      rendition.hooks &&
+      rendition.hooks.content
+    ) {
+      window.__rnSelectionMenuHookRegistered = true;
+      rendition.hooks.content.register(bindSelectionMenuBridge);
+    }
+  } catch (error) {}
+  true;
+})();
+`;

--- a/src/utils/shouldUseIosSelectionOverlay.test.ts
+++ b/src/utils/shouldUseIosSelectionOverlay.test.ts
@@ -1,0 +1,20 @@
+import { shouldUseIosSelectionOverlay } from './shouldUseIosSelectionOverlay';
+
+describe('shouldUseIosSelectionOverlay', () => {
+  it('is true only on iOS when custom menu items exist', () => {
+    expect(shouldUseIosSelectionOverlay('ios', [{ label: 'Highlight' }])).toBe(
+      true
+    );
+  });
+
+  it('is false on Android even with menu items', () => {
+    expect(
+      shouldUseIosSelectionOverlay('android', [{ label: 'Highlight' }])
+    ).toBe(false);
+  });
+
+  it('is false when the caller wants the native menu or no menu', () => {
+    expect(shouldUseIosSelectionOverlay('ios')).toBe(false);
+    expect(shouldUseIosSelectionOverlay('ios', [])).toBe(false);
+  });
+});

--- a/src/utils/shouldUseIosSelectionOverlay.ts
+++ b/src/utils/shouldUseIosSelectionOverlay.ts
@@ -1,0 +1,6 @@
+export function shouldUseIosSelectionOverlay(
+  platform: string,
+  menuItems?: Array<unknown>
+): boolean {
+  return platform === 'ios' && Array.isArray(menuItems) && menuItems.length > 0;
+}


### PR DESCRIPTION
## Summary
- On iOS, custom `menuItems` are rendered in a React Native overlay so the menu can reappear when the user adjusts or taps a selection.
- This works around a `react-native-webview` limitation on iOS 16+ ([#3798](https://github.com/react-native-webview/react-native-webview/issues/3798)): the native custom menu is not re-presented after the first selection.
- Android keeps the native WebView menu. The public `menuItems` API is unchanged.

Fixes #352
Fixes #343

## Test plan
- [ ] iOS + `menuItems`: first text selection shows the custom menu
- [ ] iOS: dragging selection handles hides/moves the menu and it reappears when the selection settles
- [ ] iOS: tapping an existing selection after the menu dismisses brings it back
- [ ] iOS: a short slide without a real selection does not show a ghost menu
- [ ] iOS: menu sits above the selection when there is room, below when there is not
- [ ] iOS: tapping a menu item still runs `action` and respects the boolean return (`true` clears selection)
- [ ] iOS without `menuItems`: the default system menu still works
- [ ] Android with `menuItems`: native context menu is unchanged
- [ ] Annotations and FullExample still highlight from the yellow/red/green items


Made with [Cursor](https://cursor.com)